### PR TITLE
Fix xbox icon

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -65,7 +65,7 @@ export const DEFAULT_BUTTONS: { [key: string]: HarmonyButtonConfig } = {
     },
     'xbox': {
         command: 'Xbox',
-        icon: 'mdi:xbox',
+        icon: 'mdi:microsoft-xbox',
         hide: false
     },
     'back': {


### PR DESCRIPTION
The icon name for xbox has been updated to microsoft-xbox. This corrects the name.