### PR TITLE
Fix order of precedence for volume_entity

### DIFF
--- a/src/harmony-card.ts
+++ b/src/harmony-card.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, customElement, property, TemplateResult, css, PropertyValues } from 'lit-element';
+ import { LitElement, html, customElement, property, TemplateResult, css, PropertyValues } from 'lit-element';
 import {
     HomeAssistant,
     hasAction,

--- a/src/harmony-card.ts
+++ b/src/harmony-card.ts
@@ -91,15 +91,13 @@ export class HarmonyCard extends LitElement {
         }
     }
 
-    protected volumeCommand(e, command: string, attributes?: any) {
+    protected volumeCommand(e, volumeMediaPlayer: string, command: string, attributes?: any) {
         this.preventBubbling(e);
 
-        if (this._config?.volume_entity) {
+        var baseAttributes = { entity_id: volumeMediaPlayer };
 
-            var baseAttributes = { entity_id: this._config?.volume_entity };
-
-            this.hass?.callService("media_player", command, Object.assign(baseAttributes, attributes || {}));
-        }
+        this.hass?.callService("media_player", command, Object.assign(baseAttributes, attributes || {}));
+		
     }
 
     protected shouldUpdate(changedProps: PropertyValues): boolean {
@@ -309,8 +307,8 @@ export class HarmonyCard extends LitElement {
 
         return html``;
     }
-
-    private renderMediaPlayerVolumeControls(hass: HomeAssistant, volumeMediaPlayer: string, buttonConfig: { [key: string]: HarmonyButtonConfig }) {
+  
+  private renderMediaPlayerVolumeControls(hass: HomeAssistant, volumeMediaPlayer: string, buttonConfig: { [key: string]: HarmonyButtonConfig }) {
         var volume_state = hass.states[volumeMediaPlayer];
 
         var volume = volume_state.attributes.volume_level;
@@ -322,10 +320,10 @@ export class HarmonyCard extends LitElement {
 
         return html`
             <div class="volume-controls">
-                <ha-icon-button style="${styleMap(volumeDownStyle)}" icon="${buttonConfig['volume_down'].icon}" @click="${e => this.volumeCommand(e, 'volume_down')}" @touchstart="${e => this.preventBubbling(e)}"></ha-icon-button>
-                <ha-icon-button style="${styleMap(volumeUpStyle)}" icon="${buttonConfig['volume_up'].icon}" @click="${e => this.volumeCommand(e, 'volume_up')}" @touchstart="${e => this.preventBubbling(e)}"></ha-icon-button>
+                <ha-icon-button style="${styleMap(volumeDownStyle)}" icon="${buttonConfig['volume_down'].icon}" @click="${e => this.volumeCommand(e, volumeMediaPlayer, 'volume_down')}" @touchstart="${e => this.preventBubbling(e)}"></ha-icon-button>
+                <ha-icon-button style="${styleMap(volumeUpStyle)}" icon="${buttonConfig['volume_up'].icon}" @click="${e => this.volumeCommand(e, volumeMediaPlayer, 'volume_up')}" @touchstart="${e => this.preventBubbling(e)}"></ha-icon-button>
                 <paper-slider           
-                    @change=${e => this.volumeCommand(e, 'volume_set', { volume_level: e.target.value / 100 })}
+                    @change=${e => this.volumeCommand(e, volumeMediaPlayer, 'volume_set', { volume_level: e.target.value / 100 })}
                     @click=${e => e.stopPropagation()}
                     @touchstart="${e => this.preventBubbling(e)}"
                     ?disabled=${muted}
@@ -335,7 +333,7 @@ export class HarmonyCard extends LitElement {
                     ignore-bar-touch pin>
                 </paper-slider>
                 
-                <ha-icon-button style="${styleMap(volumeMuteStyle)}" icon="${buttonConfig['volume_mute'].icon}" @click="${e => this.volumeCommand(e, 'volume_mute', { is_volume_muted: true })}" @touchstart="${e => this.preventBubbling(e)}"></ha-icon-button>
+                <ha-icon-button style="${styleMap(volumeMuteStyle)}" icon="${buttonConfig['volume_mute'].icon}" @click="${e => this.volumeCommand(e, volumeMediaPlayer, 'volume_mute', { is_volume_muted: true })}" @touchstart="${e => this.preventBubbling(e)}"></ha-icon-button>
             </div>`;
     }
 

--- a/src/harmony-card.ts
+++ b/src/harmony-card.ts
@@ -1,4 +1,4 @@
- import { LitElement, html, customElement, property, TemplateResult, css, PropertyValues } from 'lit-element';
+import { LitElement, html, customElement, property, TemplateResult, css, PropertyValues } from 'lit-element';
 import {
     HomeAssistant,
     hasAction,

--- a/src/harmony-card.ts
+++ b/src/harmony-card.ts
@@ -97,7 +97,9 @@ export class HarmonyCard extends LitElement {
         var baseAttributes = { entity_id: volumeMediaPlayer };
 
         this.hass?.callService("media_player", command, Object.assign(baseAttributes, attributes || {}));
-		
+
+																											 
+		 
     }
 
     protected shouldUpdate(changedProps: PropertyValues): boolean {
@@ -307,8 +309,8 @@ export class HarmonyCard extends LitElement {
 
         return html``;
     }
-  
-  private renderMediaPlayerVolumeControls(hass: HomeAssistant, volumeMediaPlayer: string, buttonConfig: { [key: string]: HarmonyButtonConfig }) {
+
+    private renderMediaPlayerVolumeControls(hass: HomeAssistant, volumeMediaPlayer: string, buttonConfig: { [key: string]: HarmonyButtonConfig }) {
         var volume_state = hass.states[volumeMediaPlayer];
 
         var volume = volume_state.attributes.volume_level;


### PR DESCRIPTION
Using volume_entity at activity level was not overriding the card level volume_entity as per order of precedence/ Fix #46 