### PR TITLE
add logic to scale volume slider to match `volume_entity` values

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Hey there! Hope you are enjoying my work. Help me out for a couple of :beers: or
 | entity            | string  | **Required** | Home Assistant entity ID of Harmony         |                     |
 | volume_entity     | string  | **Optional** | Home Assistant entity ID of volume control media_player|          |
 | volume_device     | string  | **Optional** | Harmony device name to control volume       |                     |
+| volume_scale_multiplier     | number  | **Optional** | Multiplier required to convert between `volume_entity` and volume slider | 1 |
 | hide_keyPad       | boolean | **Optional** | Hides the KeyPad                            | `true`              |
 | activites         | Activity| **Required** | List of Activities (see below)              |                     |
 | show_activities_icons | boolean  | **Optional** | Show activity buttons as icons         | `false`             |
@@ -45,6 +46,7 @@ Hey there! Hope you are enjoying my work. Help me out for a couple of :beers: or
 | icon               | string  | **Optional** | The icon to display for the button (ex. `mdi:` + http://materialdesignicons.com/)|          |
 | volume_entity      | string  | **Optional** | Home Assistant entity ID of volume control media_player|          |
 | volume_device      | string  | **Optional** | Harmony device name to control volume       |                     |
+| volume_scale_multiplier     | number  | **Optional** | Multiplier required to convert between `volume_entity` and volume slider | 1 |
 | hide_keyPad        | boolean | **Optional** | Hides the KeyPad                            | `true`              |
 | buttons            | Button Dictionary  | **Optional** | A dictionary/object of button config to override defaults |                  |
 ## Action Options
@@ -215,6 +217,8 @@ Furthermore, volume controls try to use specified media players (if configured) 
 3. Card Level volume_entity
 4. Card Level volume_device
 
+If your `volume_entity` uses a scale other than 0 (min) - 100 (max), then you can set `volume_scale_multiplier` to convert from the 0-1 scale of Home Assistant to match the numbers displayed on your receiver. For example, if your receiver goes from 0 - 60, then a multiplier of `0.6` will ensure the volume slider value matches the receiver.
+
 #### Devices
 Devices to be used for buttons follow the following order of precedence:
 1. Activity-button level device
@@ -248,6 +252,7 @@ resources:
 - type: 'custom:harmony-card'
   entity: remote.living_room_hub
   volume_entity: media_player.living_room
+  volume_scale_multiplier: 0.6
   scale: 1.25
   activities:
   - name: Play Xbox One

--- a/src/harmony-card.ts
+++ b/src/harmony-card.ts
@@ -297,13 +297,13 @@ export class HarmonyCard extends LitElement {
 
     private renderVolumeControls(hass: HomeAssistant, config: HarmonyCardConfig, buttonConfig: { [key: string]: HarmonyButtonConfig }, currentActivityConfig: HarmonyActivityConfig | undefined) {
         if (currentActivityConfig?.volume_entity) {
-            return this.renderMediaPlayerVolumeControls(hass, currentActivityConfig?.volume_entity, buttonConfig);
+            return this.renderMediaPlayerVolumeControls(hass, currentActivityConfig?.volume_entity, buttonConfig, config);
         }
         else if (currentActivityConfig?.volume_device) {
             return this.renderDeviceVolumeControls(currentActivityConfig?.volume_device, buttonConfig);
         }
         else if (config.volume_entity) {
-            return this.renderMediaPlayerVolumeControls(hass, config.volume_entity, buttonConfig);
+            return this.renderMediaPlayerVolumeControls(hass, config.volume_entity, buttonConfig, config);
         }
         else if (config.volume_device) {
             return this.renderDeviceVolumeControls(config.volume_device, buttonConfig);
@@ -312,7 +312,7 @@ export class HarmonyCard extends LitElement {
         return html``;
     }
 
-    private renderMediaPlayerVolumeControls(hass: HomeAssistant, volumeMediaPlayer: string, buttonConfig: { [key: string]: HarmonyButtonConfig }) {
+    private renderMediaPlayerVolumeControls(hass: HomeAssistant, volumeMediaPlayer: string, buttonConfig: { [key: string]: HarmonyButtonConfig }, config: HarmonyCardConfig) {
         var volume_state = hass.states[volumeMediaPlayer];
 
         var volume = volume_state.attributes.volume_level;
@@ -322,17 +322,19 @@ export class HarmonyCard extends LitElement {
         var volumeUpStyle = Object.assign({} as StyleInfo, { color: buttonConfig['volume_up'].color });
         var volumeMuteStyle = Object.assign({} as StyleInfo, { color: buttonConfig['volume_mute'].color });
 
+        const volumeMultiplier = 100 * (config.volume_scale_multiplier || 1);
+
         return html`
             <div class="volume-controls">
                 <ha-icon-button style="${styleMap(volumeDownStyle)}" icon="${buttonConfig['volume_down'].icon}" @click="${e => this.volumeCommand(e, volumeMediaPlayer, 'volume_down')}" @touchstart="${e => this.preventBubbling(e)}"><ha-icon icon="${buttonConfig['volume_down'].icon}"></ha-icon></ha-icon-button>
                 <ha-icon-button style="${styleMap(volumeUpStyle)}" icon="${buttonConfig['volume_up'].icon}" @click="${e => this.volumeCommand(e, volumeMediaPlayer, 'volume_up')}" @touchstart="${e => this.preventBubbling(e)}"><ha-icon icon="${buttonConfig['volume_up'].icon}"></ha-icon-button>
-                <paper-slider           
-                    @change=${e => this.volumeCommand(e, volumeMediaPlayer, 'volume_set', { volume_level: e.target.value / 100 })}
+                <paper-slider
+                    @change=${e => this.volumeCommand(e, volumeMediaPlayer, 'volume_set', { volume_level: e.target.value / volumeMultiplier })}
                     @click=${e => e.stopPropagation()}
                     @touchstart="${e => this.preventBubbling(e)}"
                     ?disabled=${muted}
-                    min=0 max=100
-                    value=${volume * 100}
+                    min=0 max=${volumeMultiplier}
+                    value=${volume * volumeMultiplier}
                     dir=${'ltr'}
                     ignore-bar-touch pin>
                 </paper-slider>

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface HarmonyCardConfig {
     hold_action?: ActionConfig;
     double_tap_action?: ActionConfig;
     buttons?: { [key: string]: HarmonyButtonConfig };
+    volume_scale_multiplier?: number;
 }
 
 export interface HarmonyActivityConfig {


### PR DESCRIPTION
This PR attempts to improve the value displayed on volume sliders, per this issue that I created: https://github.com/sbryfcz/harmony-card/issues/73

Feel free to improve the code, I just threw this together to get it working properly for myself.